### PR TITLE
SAF-21 [FEAT] 사용자 역할에 따른 모자이크 적용 및 해제 API 엔드포인트 구분

### DIFF
--- a/http_video_server.py
+++ b/http_video_server.py
@@ -18,6 +18,23 @@ async def video_ws(websocket: WebSocket):
             data = await websocket.receive_bytes()
             nparr = np.frombuffer(data, np.uint8)
             frame = cv2.imdecode(nparr, cv2.IMREAD_COLOR)
+            # 모자이크 적용하지 않음
+            _, jpg = cv2.imencode('.jpg', frame)
+            await websocket.send_bytes(jpg.tobytes())
+    except Exception as e:
+        print("WebSocket closed:", e)
+    finally:
+        active_websockets.discard(websocket)
+
+@app.websocket("/ws/video/mo")
+async def video_mosaic_ws(websocket: WebSocket):
+    await websocket.accept()
+    active_websockets.add(websocket)
+    try:
+        while True:
+            data = await websocket.receive_bytes()
+            nparr = np.frombuffer(data, np.uint8)
+            frame = cv2.imdecode(nparr, cv2.IMREAD_COLOR)
             frame = process_frame(frame, mode="face_plate")
             _, jpg = cv2.imencode('.jpg', frame)
             await websocket.send_bytes(jpg.tobytes())


### PR DESCRIPTION
### ⛓️‍💥 Issue Number
- #3 

  <br/>
### 🔎 Summary

- 사용자 역할에 따른 모자이크 적용 및 해제 엔드포인트 구분
- 기존 /ws/video를 /ws/video/mo로 변경하여 일반 사용자가 모자이크 영상 스트리밍
- /ws/video를 인증된 공인이 모자이크 해제된 영상을 스트리밍 할 수 있도록 변경

  <br/>
### ✅ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 코드 리팩토링
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, git template 수정)
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정/삭제


