### PR TITLE
[FIX] 재연결 불가 문제 수정

### DIFF
--- a/server/websocket_stream.py
+++ b/server/websocket_stream.py
@@ -31,7 +31,7 @@ from .config import (
 from .config import MIN_RECORD_DURATION_SEC
 import server.config as cfg  # 런타임 설정 동적 참조
 from .analytics.person_count import estimate_person_count
-from .recording import auto_start_recording_from_frame, finalize_and_notify
+from .recording import auto_start_recording_from_frame, finalize_and_notify, stop_and_finalize_recording
 from AI_processor import process_frame, process_frame_with_meta
 
 router = APIRouter()
@@ -422,6 +422,21 @@ async def unified_video_ws(websocket: WebSocket):
     finally:
         # 연결 종료/정리
         try:
+            # 이 세션이 녹화 주체였다면 대기 작업 취소 및 즉시 정리
+            try:
+                if state._recording_ws_id == ws_id:
+                    try:
+                        if state._stop_task is not None and not state._stop_task.done():
+                            state._stop_task.cancel()
+                    except Exception:
+                        pass
+                    if state.is_recording:
+                        try:
+                            await stop_and_finalize_recording()
+                        except Exception:
+                            pass
+            except Exception:
+                pass
             with state.verification_lock:
                 state.verified_users.pop(ws_id, None)
             st = state.stream_stats.get(ws_id, {})


### PR DESCRIPTION
### ⛓️‍💥 Issue Number
- #50

  <br/>
### 🔎 Summary

- disconnect된 세션이 녹화 주체면 pending finalize(_stop_task) 취소
- 진행 중 녹화는 stop_and_finalize_recording() 즉시 호출하여 VideoWriter/상태 해제
- stale is_recording/_recording_ws_id로 인한 재연결 차단 방지
- 필요한 import 보완

  <br/>
### ✅ PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 코드 리팩토링
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, git template 수정)
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정/삭제